### PR TITLE
Add option for compact Z-offset grid view

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -168,6 +168,7 @@
 #define HIGH_SPEED              1 //高速模式 1：打开高速模式 150mm/s; 0：低速模式 80mm/s 
 #define HIGH_SPEED_1            1 //只开关高速的宏  
 #define SHOW_GRID_VALUES        1 //1 显示自动调平网格值  0 不显示自动调平网格值 
+#define COMPACT_GRID_VALUES     1 // 0 - original Creality style, 1 - compact style for tight grids
 #define K8_EXTRUDER             0 //1 是K8挤出机   0 是精灵挤出机
 #define USER_LEVEL_CHECK        1 // 调平校准使能
 #define WUHAN_CHENGE_PLATFORM   1 // 武汉改平台板  20230913_Rock

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -601,6 +601,8 @@ extern enum DC_language current_language;
 // Color  FE29
 #define Color_White       0xFFFF
 #define Color_Yellow      0xFE29
+#define Color_Blue        0x19FF
+#define Color_Red         0xF44F
 #define Color_Bg_Window   0x31E8  // Popup background color
 #define Color_Bg_Blue     0x1145  // Dark blue background color
 #define Color_Bg_Black    0x0841  // Black background color

--- a/Marlin/src/lcd/dwin/e3v2/ui_position.h
+++ b/Marlin/src/lcd/dwin/e3v2/ui_position.h
@@ -4,35 +4,108 @@
 
 #if ENABLED(DWIN_CREALITY_480_LCD) //
 
-#elif ENABLED(DWIN_CREALITY_320_LCD)//3.2寸屏幕
-//主界面
-    #define LOGO_LITTLE_X  72  //小LOGO坐标
+#elif ENABLED(DWIN_CREALITY_320_LCD) //3.2-inch screen
+//Main Interface
+//Coordinates of the small logo
+    #define LOGO_LITTLE_X  72
     #define LOGO_LITTLE_Y  36
-//自动调平界面
-//编辑调平页面
+//Auto-Leveling Interface
+//Edit Leveling Page
     #define WORD_TITLE_X 29 
     #define WORD_TITLE_Y 1
-    #define OUTLINE_LEFT_X 12//40
-    #define OUTLINE_LEFT_Y 30//72
-    #define OUTLINE_RIGHT_X OUTLINE_LEFT_X+220//OUTLINE_LEFT_X+200//OUTLINE_LEFT_X+160
-    #define OUTLINE_RIGHT_Y OUTLINE_LEFT_Y+220//OUTLINE_LEFT_Y+160
+    #if GRID_MAX_POINTS_X <= 5
+        #define OUTLINE_HORIZONTAL_MARGIN 12
+    #else
+        #define OUTLINE_HORIZONTAL_MARGIN 2
+    #endif
+    #define OUTLINE_INNER_WIDTH (DWIN_WIDTH - (OUTLINE_HORIZONTAL_MARGIN * 2))
+    #define OUTLINE_INNER_HEIGHT 220
+    #define OUTLINE_LEFT_X OUTLINE_HORIZONTAL_MARGIN
+    #define OUTLINE_LEFT_Y 30
+    #define OUTLINE_RIGHT_X (OUTLINE_HORIZONTAL_MARGIN + OUTLINE_INNER_WIDTH)
+    #define OUTLINE_RIGHT_Y (OUTLINE_LEFT_Y + OUTLINE_INNER_HEIGHT)
     //button——position
     #define BUTTON_W 82
     #define BUTTON_H 32
     #define BUTTON_EDIT_X OUTLINE_LEFT_X
-    #define BUTTON_EDIT_Y OUTLINE_RIGHT_Y+20//OUTLINE_RIGHT_Y+27
+    #define BUTTON_EDIT_Y OUTLINE_RIGHT_Y+20
     #define BUTTON_OK_X  OUTLINE_RIGHT_X-BUTTON_W
-    #define BUTTON_OK_Y  BUTTON_EDIT_Y//
-    //数据坐标
-    #define X_Axis_Interval  50//54   //x轴上间隔距离像素
-    #define Y_Axis_Interval  52//35   //y轴上间隔距离像素
-    #define Rect_LU_X_POS    OUTLINE_LEFT_X+10//32   //第一个左上x坐标
-    // #define Rect_LU_Y_POS    OUTLINE_LEFT_Y+10//157-4  //第一个左上y坐标
-    #define Rect_LU_Y_POS    (OUTLINE_LEFT_Y+20)+3*Y_Axis_Interval//157-4  //第一个左上y坐标
+    #define BUTTON_OK_Y  BUTTON_EDIT_Y
+    //data coordinates
+    
+    #if ENABLED(SHOW_GRID_VALUES) && GRID_MAX_POINTS_X >= 7 && DISABLED(COMPACT_GRID_VALUES)
+        #error "Cannot fit GRID_MAX_POINTS_X >= 7 into LCD screen. Either set GRID_MAX_POINTS_X to lower value or enable COMPACT_GRID_VALUES"
+    #endif
+    #if ENABLED(SHOW_GRID_VALUES) && GRID_MAX_POINTS_X > 10
+        #error "Cannot fit GRID_MAX_POINTS_X > 10 into LCD screen. Either set GRID_MAX_POINTS_X to lower value or disable SHOW_GRID_VALUES"
+    #endif
+    #if ENABLED(SHOW_GRID_VALUES) && GRID_MAX_POINTS_Y > 10
+        #error "Cannot fit GRID_MAX_POINTS_Y > 10 into LCD screen. Either set GRID_MAX_POINTS_Y to lower value or disable SHOW_GRID_VALUES"
+    #endif
 
-    #define Rect_RD_X_POS    Rect_LU_X_POS+45//X_Axis_Interval//X_Axis_Interval//78   //第一个右下x坐标
-    // #define Rect_RD_Y_POS    Rect_LU_Y_POS+20//Y_Axis_Interval//Y_Axis_Interval//177-4  //第一个右下y坐标
-    #define Rect_RD_Y_POS    (Rect_LU_Y_POS+30)//Y_Axis_Interval//Y_Axis_Interval//177-4  //第一个右下y坐标
+    #if ENABLED(COMPACT_GRID_VALUES)
+        #define CELL_TEXT_WIDTH (3 * 8 + 1) // ".00" or "1.0" gives maximum 3 chars of 8x12 font per cell
+        #define CELL_TEXT_HEIGHT 22 // 12px for character height of 8x12 font + 10px for padding per cell
+    #else // COMPACT_GRID_VALUES
+        #define CELL_TEXT_WIDTH (5 * 8) // "-0.00" gives maximum 5 chars of 8x12 font per cell
+        #define CELL_TEXT_HEIGHT 14 // 12px for character height of 8x12 font + 14px for padding per cell
+    #endif // COMPACT_GRID_VALUES
+
+    #define _TOTAL_MIN_CELL_WIDTH (CELL_TEXT_WIDTH * GRID_MAX_POINTS_X)
+    #define _TOTAL_MIN_CELL_HEIGHT (CELL_TEXT_HEIGHT * GRID_MAX_POINTS_Y)
+
+    #define _SPACE_TO_SPREAD_HORIZONTAL (OUTLINE_INNER_WIDTH - _TOTAL_MIN_CELL_WIDTH)
+    #define _SPACE_TO_SPREAD_VERTICAL (OUTLINE_INNER_HEIGHT - _TOTAL_MIN_CELL_HEIGHT)
+
+    #if (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X + 1)) != 0 // allocate space evenly to celss and cell spacing and outer spacing
+        #define _CELL_GROW_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X + 1))
+        #define _CELL_SPACING_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X + 1))
+    #elif (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X - 1)) != 0 // allocate space evenly to celss and cell spacing
+        #define _CELL_GROW_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X - 1))
+        #define _CELL_SPACING_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / (GRID_MAX_POINTS_X + GRID_MAX_POINTS_X - 1))
+    #elif (_SPACE_TO_SPREAD_HORIZONTAL / GRID_MAX_POINTS_X) != 0 // allocate space evenly to cells
+        #define _CELL_GROW_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / GRID_MAX_POINTS_X)
+        #define _CELL_SPACING_HORIZONTAL 0
+    #elif (_SPACE_TO_SPREAD_HORIZONTAL / GRID_MAX_POINTS_X - 1) != 0 // allocate space evenly to cell spacing
+        #define _CELL_GROW_HORIZONTAL 0
+        #define _CELL_SPACING_HORIZONTAL (_SPACE_TO_SPREAD_HORIZONTAL / GRID_MAX_POINTS_X - 1)
+    #else
+        #define _CELL_GROW_HORIZONTAL 0
+        #define _CELL_SPACING_HORIZONTAL 0
+    #endif
+
+    #if (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y + 1)) != 0 // allocate space evenly to celss and cell spacing
+        #define _CELL_GROW_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y + 1))
+        #define _CELL_SPACING_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y + 1))
+    #elif (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y - 1)) != 0 // allocate space evenly to celss and cell spacing
+        #define _CELL_GROW_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y - 1))
+        #define _CELL_SPACING_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / (GRID_MAX_POINTS_Y + GRID_MAX_POINTS_Y - 1))
+    #elif (_SPACE_TO_SPREAD_VERTICAL / GRID_MAX_POINTS_Y) != 0 // allocate space evenly to cells
+        #define _CELL_GROW_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / GRID_MAX_POINTS_Y)
+        #define _CELL_SPACING_VERTICAL 0
+    #elif (_SPACE_TO_SPREAD_VERTICAL / GRID_MAX_POINTS_Y - 1) != 0 // allocate space evenly to cell spacing
+        #define _CELL_GROW_VERTICAL 0
+        #define _CELL_SPACING_VERTICAL (_SPACE_TO_SPREAD_VERTICAL / GRID_MAX_POINTS_Y - 1)
+    #else
+        #define _CELL_GROW_VERTICAL 0
+        #define _CELL_SPACING_VERTICAL 0
+    #endif
+
+    #define CELL_WIDTH (CELL_TEXT_WIDTH + _CELL_GROW_HORIZONTAL)
+    #define CELL_HEIGHT (CELL_TEXT_HEIGHT + _CELL_GROW_VERTICAL)
+
+    #define X_Axis_Interval (CELL_WIDTH + _CELL_SPACING_HORIZONTAL)
+    #define Y_Axis_Interval (CELL_HEIGHT + _CELL_SPACING_VERTICAL)
+    
+    #define _CELLS_WITH_SPACING_WIDTH    ((GRID_MAX_POINTS_X * CELL_WIDTH) + ((GRID_MAX_POINTS_X - 1) * _CELL_SPACING_HORIZONTAL))
+    #define _CELLS_WITH_SPACING_HEIGHT   ((GRID_MAX_POINTS_Y * CELL_HEIGHT) + ((GRID_MAX_POINTS_Y - 1) * _CELL_SPACING_VERTICAL))
+    #define _OUTLINE_PADDING_HORIZONTAL  ((OUTLINE_INNER_WIDTH - _CELLS_WITH_SPACING_WIDTH) / 2)
+    #define _OUTLINE_PADDING_VERTICAL    ((OUTLINE_INNER_HEIGHT - _CELLS_WITH_SPACING_HEIGHT) / 2)
+
+    #define Rect_LU_X_POS    (OUTLINE_LEFT_X + _OUTLINE_PADDING_HORIZONTAL) // top-left X of the first (bottom-left) cell
+    #define Rect_LU_Y_POS    (OUTLINE_LEFT_Y + OUTLINE_INNER_HEIGHT - _OUTLINE_PADDING_VERTICAL - CELL_HEIGHT) // top-left Y of the first (bottom-left) cell
+    #define Rect_RD_X_POS    (Rect_LU_X_POS + CELL_WIDTH) // bottom-right X of the first (bottom-left) cell
+    #define Rect_RD_Y_POS    (Rect_LU_Y_POS + CELL_HEIGHT) // bottom-right Y of the first (bottom-left) cell
 	
 #define TITLE_X 29
 #define TITLE_Y  1


### PR DESCRIPTION
Rewrote cell boundaries calculation and text rendering logic so that cell sise is calculated based on the screen size and grid density.
Added an option for compact value rendering, which utilizes more of vertical space and properly renders up to 10x10 bed leveling grid.
Added some sanity checks.

![4x4-compact](https://github.com/user-attachments/assets/d131c3bc-82ff-4f4b-bf33-172a4308ae3e)
![6x6-normal](https://github.com/user-attachments/assets/168adbae-aa6b-4d0f-850b-a922e8f6ad20)
![6x6-compact](https://github.com/user-attachments/assets/a61fce4e-e56b-4ed3-bbc2-7f7a16b6591e)
![7x7-compact](https://github.com/user-attachments/assets/31af2ff7-77f9-4df9-9e3d-32c1b3825a94)
![10x10-compact](https://github.com/user-attachments/assets/3a8c057a-ab8c-4132-9549-a7774b994954)
