### PR TITLE
Add 'Input Shaping' settings menu.

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -98,6 +98,13 @@ enum processID : uint8_t {
   MaxJerk_value,
   Step,
   Step_value,
+  #if ENABLED(HIGH_SPEED)
+    InputShaping,
+    InputShaping_XFreq,
+    InputShaping_XZeta,
+    InputShaping_YFreq,
+    InputShaping_YZeta,
+  #endif // ENABLED(HIGH_SPEED)
   HomeOff,
   HomeOffX,
   HomeOffY,
@@ -645,6 +652,9 @@ typedef struct
   float Move_X_scaled     = 0;
   float Move_Y_scaled     = 0;
   float Move_Z_scaled     = 0;
+  #if ENABLED(HIGH_SPEED)
+    float InputShaping_scaled = 0;
+  #endif // ENABLED(HIGH_SPEED)
   uint8_t Curve_index = 0;
   uint16_t Auto_PID_Temp  = 0;
   uint16_t Auto_PID_Value[3] = {0, 100, 260}; // 1:热床温度; 2 喷嘴温度

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -347,6 +347,13 @@ namespace Language_en {
   PROGMEM Language_Str MSG_AMAX_EN                         = _UxGT("Amax *");
   PROGMEM Language_Str MSG_A_RETRACT                       = _UxGT("A-Retract");
   PROGMEM Language_Str MSG_A_TRAVEL                        = _UxGT("A-Travel");
+#if ENABLED(HIGH_SPEED)
+  PROGMEM Language_Str MSG_INPUT_SHAPING                   = _UxGT("Input Shaping");
+  PROGMEM Language_Str MSG_SHAPING_A_FREQ                  = LCD_STR_A _UxGT(" frequency");
+  PROGMEM Language_Str MSG_SHAPING_B_FREQ                  = LCD_STR_B _UxGT(" frequency");
+  PROGMEM Language_Str MSG_SHAPING_A_ZETA                  = LCD_STR_A _UxGT(" damping");
+  PROGMEM Language_Str MSG_SHAPING_B_ZETA                  = LCD_STR_B _UxGT(" damping");
+#endif // ENABLED(HIGH_SPEED)
   PROGMEM Language_Str MSG_XY_FREQUENCY_LIMIT              = _UxGT("Frequency max");
   PROGMEM Language_Str MSG_XY_FREQUENCY_FEEDRATE           = _UxGT("Feed min");
   PROGMEM Language_Str MSG_STEPS_PER_MM                    = _UxGT("Steps/mm");


### PR DESCRIPTION
While inout shaping is enabled in stock firmware and has some factory preset, many users change their toolhead configuration (linear rails, ceramic heater, different cooling fans, etc.), which should be followed by re-calibration of those Input Shaping params.

This patch adds an 'Input Shaping' menu item to 'Motion' menu of 'Control' section. It should allow adjusting X/Y frequency and zeta (aka damping factor) values right from LCD screen, without the need of external host.

![image](https://github.com/user-attachments/assets/129a48c6-58fb-46ea-a68c-c05b78dcea7c)
![image](https://github.com/user-attachments/assets/830b9744-9575-4643-bf9a-76a2366628ef)